### PR TITLE
Optimize React performance across all wrapper components

### DIFF
--- a/src/ChartGPU.tsx
+++ b/src/ChartGPU.tsx
@@ -4,7 +4,6 @@ import {
   useState,
   useImperativeHandle,
   forwardRef,
-  useCallback,
 } from 'react';
 import { ChartGPU as ChartGPULib } from '@chartgpu/chartgpu';
 import type {
@@ -15,24 +14,7 @@ import type {
   MouseOverParams,
 } from './types';
 import type { ChartGPUOptions, ChartGPUZoomRangeChangePayload } from '@chartgpu/chartgpu';
-
-/**
- * Debounce utility for throttling frequent calls.
- */
-function debounce<T extends (...args: any[]) => void>(
-  fn: T,
-  delayMs: number
-): (...args: Parameters<T>) => void {
-  let timeoutId: ReturnType<typeof setTimeout> | null = null;
-  return (...args: Parameters<T>) => {
-    if (timeoutId !== null) {
-      clearTimeout(timeoutId);
-    }
-    timeoutId = setTimeout(() => {
-      fn(...args);
-    }, delayMs);
-  };
-}
+import { debounce } from './utils';
 
 /**
  * ChartGPU React component.
@@ -84,8 +66,32 @@ export const ChartGPU = forwardRef<ChartGPUHandle, ChartGPUProps>(
     const instanceRef = useRef<ChartInstance | null>(null);
     const [chart, setChart] = useState<ChartInstance | null>(null);
     const mountedRef = useRef<boolean>(false);
-    const resizeObserverRef = useRef<ResizeObserver | null>(null);
     const gpuContextRef = useRef(gpuContext);
+
+    // --- Callback refs: keep handlers in refs so effects never re-subscribe ---
+    const onReadyRef = useRef(onReady);
+    onReadyRef.current = onReady;
+
+    const onClickRef = useRef(onClick);
+    onClickRef.current = onClick;
+
+    const onMouseOverRef = useRef(onMouseOver);
+    onMouseOverRef.current = onMouseOver;
+
+    const onMouseOutRef = useRef(onMouseOut);
+    onMouseOutRef.current = onMouseOut;
+
+    const onCrosshairMoveRef = useRef(onCrosshairMove);
+    onCrosshairMoveRef.current = onCrosshairMove;
+
+    const onDataAppendRef = useRef(onDataAppend);
+    onDataAppendRef.current = onDataAppend;
+
+    const onDeviceLostRef = useRef(onDeviceLost);
+    onDeviceLostRef.current = onDeviceLost;
+
+    const onZoomChangeRef = useRef(onZoomChange);
+    onZoomChangeRef.current = onZoomChange;
 
     // Expose imperative handle
     useImperativeHandle(
@@ -169,17 +175,6 @@ export const ChartGPU = forwardRef<ChartGPUHandle, ChartGPUProps>(
       []
     );
 
-    // Build effective options with theme override if provided
-    const getEffectiveOptions = useCallback((): ChartGPUOptions => {
-      if (theme !== undefined) {
-        return {
-          ...options,
-          theme,
-        };
-      }
-      return options;
-    }, [options, theme]);
-
     // Initialize chart on mount
     useEffect(() => {
       if (!containerRef.current) return;
@@ -191,7 +186,7 @@ export const ChartGPU = forwardRef<ChartGPUHandle, ChartGPUProps>(
         try {
           if (!containerRef.current) return;
 
-          const effectiveOptions = getEffectiveOptions();
+          const effectiveOptions = theme !== undefined ? { ...options, theme } : options;
           const ctx = gpuContextRef.current;
           chartInstance = ctx
             ? await ChartGPULib.create(containerRef.current, effectiveOptions, ctx)
@@ -201,7 +196,7 @@ export const ChartGPU = forwardRef<ChartGPUHandle, ChartGPUProps>(
           if (mountedRef.current) {
             instanceRef.current = chartInstance;
             setChart(chartInstance);
-            onReady?.(chartInstance);
+            onReadyRef.current?.(chartInstance);
           } else {
             // Component unmounted during async create - dispose immediately
             chartInstance.dispose();
@@ -232,17 +227,17 @@ export const ChartGPU = forwardRef<ChartGPUHandle, ChartGPUProps>(
       const instance = chart;
       if (!instance || instance.disposed) return;
 
-      const effectiveOptions = getEffectiveOptions();
+      const effectiveOptions = theme !== undefined ? { ...options, theme } : options;
       instance.setOption(effectiveOptions);
-    }, [chart, options, theme, getEffectiveOptions]);
+    }, [chart, options, theme]);
 
     // Register/unregister click event handler
     useEffect(() => {
       const instance = chart;
-      if (!instance || instance.disposed || !onClick) return;
+      if (!instance || instance.disposed) return;
 
       const handler = (payload: ClickParams) => {
-        onClick(payload);
+        onClickRef.current?.(payload);
       };
 
       instance.on('click', handler);
@@ -254,15 +249,15 @@ export const ChartGPU = forwardRef<ChartGPUHandle, ChartGPUProps>(
           // instance may already be disposed; swallow
         }
       };
-    }, [chart, onClick]);
+    }, [chart]);
 
     // Register/unregister mouseover event handler
     useEffect(() => {
       const instance = chart;
-      if (!instance || instance.disposed || !onMouseOver) return;
+      if (!instance || instance.disposed) return;
 
       const handler = (payload: MouseOverParams) => {
-        onMouseOver(payload);
+        onMouseOverRef.current?.(payload);
       };
 
       instance.on('mouseover', handler);
@@ -274,15 +269,15 @@ export const ChartGPU = forwardRef<ChartGPUHandle, ChartGPUProps>(
           // instance may already be disposed; swallow
         }
       };
-    }, [chart, onMouseOver]);
+    }, [chart]);
 
     // Register/unregister mouseout event handler
     useEffect(() => {
       const instance = chart;
-      if (!instance || instance.disposed || !onMouseOut) return;
+      if (!instance || instance.disposed) return;
 
       const handler = (payload: ClickParams) => {
-        onMouseOut(payload);
+        onMouseOutRef.current?.(payload);
       };
 
       instance.on('mouseout', handler);
@@ -294,15 +289,15 @@ export const ChartGPU = forwardRef<ChartGPUHandle, ChartGPUProps>(
           // instance may already be disposed; swallow
         }
       };
-    }, [chart, onMouseOut]);
+    }, [chart]);
 
     // Register/unregister crosshairMove event handler
     useEffect(() => {
       const instance = chart;
-      if (!instance || instance.disposed || !onCrosshairMove) return;
+      if (!instance || instance.disposed) return;
 
       const handler = (payload: Parameters<NonNullable<ChartGPUProps['onCrosshairMove']>>[0]) => {
-        onCrosshairMove(payload);
+        onCrosshairMoveRef.current?.(payload);
       };
 
       instance.on('crosshairMove', handler);
@@ -314,15 +309,15 @@ export const ChartGPU = forwardRef<ChartGPUHandle, ChartGPUProps>(
           // instance may already be disposed; swallow
         }
       };
-    }, [chart, onCrosshairMove]);
+    }, [chart]);
 
     // Register/unregister dataAppend event handler
     useEffect(() => {
       const instance = chart;
-      if (!instance || instance.disposed || !onDataAppend) return;
+      if (!instance || instance.disposed) return;
 
       const handler = (payload: Parameters<NonNullable<ChartGPUProps['onDataAppend']>>[0]) => {
-        onDataAppend(payload);
+        onDataAppendRef.current?.(payload);
       };
 
       instance.on('dataAppend', handler);
@@ -334,15 +329,15 @@ export const ChartGPU = forwardRef<ChartGPUHandle, ChartGPUProps>(
           // instance may already be disposed; swallow
         }
       };
-    }, [chart, onDataAppend]);
+    }, [chart]);
 
     // Register/unregister deviceLost event handler
     useEffect(() => {
       const instance = chart;
-      if (!instance || instance.disposed || !onDeviceLost) return;
+      if (!instance || instance.disposed) return;
 
       const handler = (payload: Parameters<NonNullable<ChartGPUProps['onDeviceLost']>>[0]) => {
-        onDeviceLost(payload);
+        onDeviceLostRef.current?.(payload);
       };
 
       instance.on('deviceLost', handler);
@@ -354,7 +349,7 @@ export const ChartGPU = forwardRef<ChartGPUHandle, ChartGPUProps>(
           // instance may already be disposed; swallow
         }
       };
-    }, [chart, onDeviceLost]);
+    }, [chart]);
 
     // Set up ResizeObserver for responsive sizing (debounced 100ms)
     useEffect(() => {
@@ -373,11 +368,9 @@ export const ChartGPU = forwardRef<ChartGPUHandle, ChartGPUProps>(
       });
 
       observer.observe(container);
-      resizeObserverRef.current = observer;
 
       return () => {
         observer.disconnect();
-        resizeObserverRef.current = null;
       };
       // Intentionally omitting containerRef.current from dependencies
       // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -388,11 +381,11 @@ export const ChartGPU = forwardRef<ChartGPUHandle, ChartGPUProps>(
     // so consumers don't need to wait for user interaction to receive the first value.
     useEffect(() => {
       const instance = chart;
-      if (!instance || instance.disposed || !onZoomChange) return;
+      if (!instance || instance.disposed) return;
 
       const handler = (payload: ChartGPUZoomRangeChangePayload) => {
         // Map upstream payload to ZoomRange (strip `source`)
-        onZoomChange({ start: payload.start, end: payload.end });
+        onZoomChangeRef.current?.({ start: payload.start, end: payload.end });
       };
 
       instance.on('zoomRangeChange', handler);
@@ -400,7 +393,7 @@ export const ChartGPU = forwardRef<ChartGPUHandle, ChartGPUProps>(
       // Hydrate: fire once with the current zoom range (if non-null)
       const current = instance.getZoomRange();
       if (current) {
-        onZoomChange({ start: current.start, end: current.end });
+        onZoomChangeRef.current?.({ start: current.start, end: current.end });
       }
 
       return () => {
@@ -410,7 +403,7 @@ export const ChartGPU = forwardRef<ChartGPUHandle, ChartGPUProps>(
           // instance may already be disposed; swallow
         }
       };
-    }, [chart, onZoomChange]);
+    }, [chart]);
 
     return (
       <div

--- a/src/ChartGPUChart.tsx
+++ b/src/ChartGPUChart.tsx
@@ -1,7 +1,13 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { CSSProperties } from 'react';
 import type { ChartGPUOptions, ChartGPUInstance } from '@chartgpu/chartgpu';
 import { ChartGPU } from './ChartGPU';
+
+const DEFAULT_STYLE: CSSProperties = {
+  position: 'relative',
+  width: '100%',
+  height: '400px',
+};
 
 export interface ChartGPUChartProps {
   /**
@@ -71,6 +77,19 @@ export function ChartGPUChart({
 }: ChartGPUChartProps): JSX.Element {
   const didInitRef = useRef(false);
 
+  const onInitRef = useRef(onInit);
+  onInitRef.current = onInit;
+
+  const handleReady = useCallback((instance: ChartGPUInstance) => {
+    didInitRef.current = true;
+    onInitRef.current?.(instance);
+  }, []);
+
+  const mergedStyle = useMemo(
+    () => (style ? { ...DEFAULT_STYLE, ...style } : DEFAULT_STYLE),
+    [style]
+  );
+
   useEffect(() => {
     return () => {
       if (didInitRef.current) {
@@ -82,17 +101,9 @@ export function ChartGPUChart({
   return (
     <ChartGPU
       className={className}
-      style={{
-        position: 'relative',
-        width: '100%',
-        height: '400px',
-        ...style,
-      }}
+      style={mergedStyle}
       options={options}
-      onReady={(instance: ChartGPUInstance) => {
-        didInitRef.current = true;
-        onInit?.(instance);
-      }}
+      onReady={handleReady}
     />
   );
 }

--- a/src/createAnnotationAuthoring.ts
+++ b/src/createAnnotationAuthoring.ts
@@ -295,19 +295,20 @@ export function createAnnotationAuthoring(
   const ensureMenu = () => {
     if (menu) return menu;
     const el = doc.createElement('div');
-    el.style.position = 'fixed';
-    el.style.display = 'none';
-    el.style.backgroundColor = '#1a1a2e';
-    el.style.border = '1px solid #333';
-    el.style.borderRadius = '8px';
-    el.style.boxShadow = '0 4px 12px rgba(0, 0, 0, 0.5)';
-    el.style.zIndex = String(options?.menuZIndex ?? 1000);
-    el.style.minWidth = '180px';
-    el.style.padding = '6px 0';
-    el.style.fontFamily =
-      '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
-    el.style.fontSize = '14px';
-    el.style.color = '#e0e0e0';
+    el.style.cssText = [
+      'position: fixed',
+      'display: none',
+      'background-color: #1a1a2e',
+      'border: 1px solid #333',
+      'border-radius: 8px',
+      'box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5)',
+      `z-index: ${options?.menuZIndex ?? 1000}`,
+      'min-width: 180px',
+      'padding: 6px 0',
+      'font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+      'font-size: 14px',
+      'color: #e0e0e0',
+    ].join('; ');
     el.setAttribute('role', 'menu');
     el.setAttribute('aria-label', 'Annotation actions');
     el.setAttribute('aria-hidden', 'true');
@@ -321,16 +322,18 @@ export function createAnnotationAuthoring(
     item.type = 'button';
     item.textContent = label;
     item.setAttribute('role', 'menuitem');
-    item.style.padding = '8px 16px';
-    item.style.cursor = 'pointer';
-    item.style.userSelect = 'none';
-    item.style.transition = 'background-color 0.15s';
-    item.style.background = 'transparent';
-    item.style.border = 'none';
-    item.style.color = 'inherit';
-    item.style.width = '100%';
-    item.style.textAlign = 'left';
-    item.style.font = 'inherit';
+    item.style.cssText = [
+      'padding: 8px 16px',
+      'cursor: pointer',
+      'user-select: none',
+      'transition: background-color 0.15s',
+      'background: transparent',
+      'border: none',
+      'color: inherit',
+      'width: 100%',
+      'text-align: left',
+      'font: inherit',
+    ].join('; ');
     item.addEventListener('mouseenter', () => {
       item.style.backgroundColor = '#2a2a3e';
     });
@@ -424,7 +427,7 @@ export function createAnnotationAuthoring(
   canvas.addEventListener('contextmenu', onContextMenuCapture, true);
   doc.addEventListener('click', onDocumentClick);
   doc.addEventListener('keydown', onKeyDown);
-  win.addEventListener('scroll', onRepositionTriggers, true);
+  win.addEventListener('scroll', onRepositionTriggers, { capture: true, passive: true });
   win.addEventListener('resize', onRepositionTriggers);
 
   const upstreamDispose = upstream.dispose.bind(upstream);
@@ -435,7 +438,7 @@ export function createAnnotationAuthoring(
     canvas.removeEventListener('contextmenu', onContextMenuCapture, true);
     doc.removeEventListener('click', onDocumentClick);
     doc.removeEventListener('keydown', onKeyDown);
-    win.removeEventListener('scroll', onRepositionTriggers, true);
+    win.removeEventListener('scroll', onRepositionTriggers, { capture: true });
     win.removeEventListener('resize', onRepositionTriggers);
     if (menu) {
       menu.remove();

--- a/src/useChartGPU.ts
+++ b/src/useChartGPU.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { ChartGPU as ChartGPULib } from '@chartgpu/chartgpu';
 import type { ChartGPUCreateContext, ChartGPUOptions } from '@chartgpu/chartgpu';
 import type { ChartInstance } from './types';
+import { debounce } from './utils';
 
 /**
  * Result object returned by the useChartGPU hook.
@@ -22,24 +23,6 @@ export interface UseChartGPUResult {
    * Null when no error has occurred.
    */
   error: Error | null;
-}
-
-/**
- * Debounce utility for throttling frequent calls.
- */
-function debounce<T extends (...args: any[]) => void>(
-  fn: T,
-  delayMs: number
-): (...args: Parameters<T>) => void {
-  let timeoutId: ReturnType<typeof setTimeout> | null = null;
-  return (...args: Parameters<T>) => {
-    if (timeoutId !== null) {
-      clearTimeout(timeoutId);
-    }
-    timeoutId = setTimeout(() => {
-      fn(...args);
-    }, delayMs);
-  };
 }
 
 /**
@@ -80,11 +63,9 @@ export function useChartGPU(
   gpuContext?: ChartGPUCreateContext
 ): UseChartGPUResult {
   const [chart, setChart] = useState<ChartInstance | null>(null);
-  const [isReady, setIsReady] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
   const mountedRef = useRef<boolean>(false);
-  const resizeObserverRef = useRef<ResizeObserver | null>(null);
   const gpuContextRef = useRef(gpuContext);
 
   // Initialize chart on mount
@@ -114,7 +95,6 @@ export function useChartGPU(
         // StrictMode safety: only update state if still mounted
         if (mountedRef.current) {
           setChart(chartInstance);
-          setIsReady(true);
           setError(null);
         } else {
           // Component unmounted during async create - dispose immediately
@@ -126,7 +106,6 @@ export function useChartGPU(
           const normalizedError =
             err instanceof Error ? err : new Error(String(err));
           setError(normalizedError);
-          setIsReady(false);
         }
       }
     };
@@ -136,15 +115,9 @@ export function useChartGPU(
     // Cleanup on unmount
     return () => {
       mountedRef.current = false;
-      setIsReady(false);
 
       if (chartInstance && !chartInstance.disposed) {
         chartInstance.dispose();
-      }
-
-      if (resizeObserverRef.current) {
-        resizeObserverRef.current.disconnect();
-        resizeObserverRef.current = null;
       }
     };
     // Intentionally omitting containerRef.current from dependencies to avoid re-initialization
@@ -174,15 +147,13 @@ export function useChartGPU(
     });
 
     observer.observe(container);
-    resizeObserverRef.current = observer;
 
     return () => {
       observer.disconnect();
-      resizeObserverRef.current = null;
     };
     // Intentionally omitting containerRef.current from dependencies
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chart]);
 
-  return { chart, isReady, error };
+  return { chart, isReady: chart !== null, error };
 }

--- a/src/useGPUContext.ts
+++ b/src/useGPUContext.ts
@@ -21,11 +21,20 @@ export interface UseGPUContextResult {
  * - Pass `{ adapter, device, pipelineCache }` to each `<ChartGPU gpuContext={...} />`
  *   or to `useChartGPU(containerRef, options, gpuContext)`.
  */
+interface GPUContextState {
+  adapter: ChartGPUCreateContext['adapter'] | null;
+  device: ChartGPUCreateContext['device'] | null;
+  pipelineCache: PipelineCache | null;
+  error: Error | null;
+}
+
 export function useGPUContext(): UseGPUContextResult {
-  const [adapter, setAdapter] = useState<ChartGPUCreateContext['adapter'] | null>(null);
-  const [device, setDevice] = useState<ChartGPUCreateContext['device'] | null>(null);
-  const [pipelineCache, setPipelineCache] = useState<PipelineCache | null>(null);
-  const [error, setError] = useState<Error | null>(null);
+  const [state, setState] = useState<GPUContextState>({
+    adapter: null,
+    device: null,
+    pipelineCache: null,
+    error: null,
+  });
 
   // StrictMode safety: avoid double-initializing in dev (effect is invoked twice).
   const startedRef = useRef(false);
@@ -55,17 +64,11 @@ export function useGPUContext(): UseGPUContextResult {
 
         if (cancelled) return;
 
-        setAdapter(nextAdapter);
-        setDevice(nextDevice);
-        setPipelineCache(nextCache);
-        setError(null);
+        setState({ adapter: nextAdapter, device: nextDevice, pipelineCache: nextCache, error: null });
       } catch (err) {
         if (cancelled) return;
         const normalized = err instanceof Error ? err : new Error(String(err));
-        setError(normalized);
-        setAdapter(null);
-        setDevice(null);
-        setPipelineCache(null);
+        setState({ adapter: null, device: null, pipelineCache: null, error: normalized });
       }
     };
 
@@ -77,11 +80,8 @@ export function useGPUContext(): UseGPUContextResult {
   }, []);
 
   return {
-    adapter,
-    device,
-    pipelineCache,
-    isReady: adapter !== null && device !== null,
-    error,
+    ...state,
+    isReady: state.adapter !== null && state.device !== null,
   };
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared utility functions for chartgpu-react.
+ */
+
+/**
+ * Debounce utility for throttling frequent calls.
+ */
+export function debounce<T extends (...args: any[]) => void>(
+  fn: T,
+  delayMs: number
+): (...args: Parameters<T>) => void {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  return (...args: Parameters<T>) => {
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+    }
+    timeoutId = setTimeout(() => {
+      fn(...args);
+    }, delayMs);
+  };
+}


### PR DESCRIPTION
- Use ref-based event handler pattern in ChartGPU.tsx to prevent unnecessary effect re-subscriptions when consumers pass inline callbacks
- Fix onReady stale closure by storing callback in ref
- Derive isReady from chart state instead of redundant useState in useChartGPU
- Consolidate 4 separate useState calls into single atomic state in useGPUContext
- Hoist default style constant and memoize merge in ChartGPUChart
- Stabilize onReady callback identity in ChartGPUChart via useCallback + ref
- Extract shared debounce utility to src/utils.ts
- Make scroll listener passive in createAnnotationAuthoring
- Batch CSS mutations with cssText in annotation context menu
- Remove unnecessary useCallback wrapper for getEffectiveOptions
- Remove dead resizeObserverRef from ChartGPU and useChartGPU